### PR TITLE
scanner loses alignment across 256kb chunk boundaries

### DIFF
--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -637,8 +637,14 @@ QVector<ScanResult> ScanEngine::runScan(std::shared_ptr<Provider> prov,
             uint64_t advance;
             if ((uint64_t)readLen >= remaining)
                 advance = remaining;  // last chunk, no overlap needed
-            else if (readLen > overlap)
-                advance = (uint64_t)(readLen - overlap);
+             else if (readLen > overlap) {
+                  advance = (uint64_t)(readLen - overlap);
+                  if (alignment > 1) {
+                      uint64_t nextOff = off + advance;
+                      uint64_t aligned = ((nextOff + alignment - 1) / alignment) * alignment;
+                      advance = aligned - off;
+                  }
+            }
             else
                 advance = 1; // prevent infinite loop on tiny regions
             scannedBytes += advance;


### PR DESCRIPTION
(made a mistake, its 256kb indeed and not 256mb)

The way chunks advance through memory doesn't account for the scan's alignment. The overlap logic handles patterns that straddle chunk boundaries fine, but the advance itself is just chunkSize - (patternLen - 1), which isn't guaranteed to be a multiple of the alignment.

For instance, say you're scanning for an Int32 (alignment = 4):
```
chunk size = 262144
overlap = patternLen - 1 = 3
advance = 262144 - 3 = 262141
262141 % 4 = 1 — not aligned
```

So the second chunk starts at a 1-byte offset from where it should. From there, every address it checks is misaligned, and all the real hits get skipped entirely. This breaks every typed value scan (Int32, Float, Double, Vec3, etc.) on any region larger than 256KB, which is basically all of them in practice. The fix rounds the advance down to the nearest multiple of the alignment so chunk boundaries stay lined up.